### PR TITLE
Add Android Compose project skeleton

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,11 @@
+/build/
+/.gradle/
+/captures/
+.externalNativeBuild/
+.cxx/
+local.properties
+*.iml
+.DS_Store
+.gradle/
+app/build/
+gradle/wrapper/gradle-wrapper.jar

--- a/android/README_app.md
+++ b/android/README_app.md
@@ -1,0 +1,64 @@
+# SOON Autobiography Android App
+
+## 프로젝트 개요
+
+`android/` 디렉터리에는 Jetpack Compose, Hilt, Room, WorkManager, Retrofit2, Kotlinx Serialization, Security Crypto 등을 사용하는 안드로이드 애플리케이션이 포함되어 있습니다. 패키지명은 `com.yourcompany.biography` 입니다.
+
+## 개발 환경 준비
+
+1. **Android Studio** 최신 버전 설치 (또는 설치된 JDK 17과 Android SDK 34).
+2. `ANDROID_HOME` 또는 `ANDROID_SDK_ROOT` 환경변수가 올바르게 설정되어 있는지 확인합니다.
+3. 리포지토리 루트에서 안드로이드 프로젝트 디렉터리로 이동합니다.
+
+```bash
+cd android
+```
+
+> ⚠️ 현재 저장소에는 `gradle-wrapper.jar` 등 바이너리 파일이 포함되어 있지 않습니다. 프로젝트 빌드 전에 아래 명령으로 Gradle Wrapper를 생성하거나, 로컬에 설치된 Gradle을 사용해 주세요.
+>
+> ```bash
+> gradle wrapper
+> ```
+>
+> 또는 Android Studio가 자동으로 Wrapper 파일을 내려받도록 둘 수 있습니다.
+
+## 빌드 및 실행
+
+Gradle Wrapper를 준비한 뒤 다음 명령으로 디버그 빌드를 수행할 수 있습니다.
+
+```bash
+./gradlew assembleDebug
+```
+
+Android Studio에서 `Run` ▶︎ `Run 'app'`을 실행하면 에뮬레이터 또는 연결된 기기에서 앱을 실행할 수 있습니다.
+
+## 권한
+
+앱은 생애 기록을 위한 오디오 녹음을 위해 다음과 같은 권한이 필요합니다.
+
+- `android.permission.RECORD_AUDIO`
+- `android.permission.POST_NOTIFICATIONS` (Android 13 이상에서 녹음 진행 알림 제공 시 필요)
+- 필요에 따라 `android.permission.READ_MEDIA_AUDIO` 또는 저장소 권한
+
+`AndroidManifest.xml`에는 관련 TODO 주석이 포함되어 있으며, 실제 녹음 기능을 연결할 때 권한과 Foreground Service 타입을 정확히 지정해 주세요. 런타임 권한 요청 로직 역시 구현이 필요합니다.
+
+## 주요 구성 요소
+
+- **Jetpack Compose UI**: `ui/` 패키지에 메인 화면, 녹음 컨트롤, 질문 위저드 UI가 위치합니다.
+- **Hilt 의존성 주입**: `di/` 패키지에서 Retrofit, Room, Repository, Dispatcher 등을 제공합니다.
+- **Room**: `data/local/` 패키지에 데이터베이스, DAO, 엔티티가 정의되어 있습니다.
+- **Remote API**: `data/remote/` 패키지에 Retrofit 서비스 인터페이스가 정의되어 있으며 Kotlinx Serialization으로 응답을 파싱합니다.
+- **Repository**: `data/repo/` 패키지가 로컬/원격 데이터를 통합합니다.
+- **WorkManager**: `worker/RecordingWorker`가 백그라운드 동기화를 담당하도록 준비되어 있습니다.
+- **EncryptedFile**: `util/EncryptedFileManager`가 민감한 데이터를 안전하게 보관할 수 있도록 도와줍니다.
+
+## 접근성
+
+메인 화면에는 최소 높이 48dp의 “녹음 시작” 버튼이 배치되어 있으며, TalkBack 사용자를 위한 접근성 라벨이 포함되어 있습니다. 큰 글씨 모드에서도 읽기 쉬운 `MaterialTheme.typography.titleLarge` 스타일을 사용합니다.
+
+## TODO
+
+- 실제 녹음 기능과 Foreground Service 동작 연결
+- 질문 위저드와 데이터 연동
+- 런타임 권한 요청 UX 구현
+- 백엔드 API 연동 및 에러 처리 고도화

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,98 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.kapt)
+}
+
+android {
+    namespace = "com.yourcompany.biography"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.yourcompany.biography"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.dagger.hilt.android)
+    kapt(libs.dagger.hilt.compiler)
+    implementation(libs.androidx.hilt.work)
+    kapt(libs.androidx.hilt.compiler)
+
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    kapt(libs.room.compiler)
+
+    implementation(libs.androidx.work.ktx)
+
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.serialization)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.androidx.security.crypto)
+
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+kapt {
+    correctErrorTypes = true
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/android/app/src/androidTest/java/com/yourcompany/biography/ExampleInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/yourcompany/biography/ExampleInstrumentedTest.kt
@@ -1,0 +1,16 @@
+package com.yourcompany.biography
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("com.yourcompany.biography", appContext.packageName)
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.yourcompany.biography">
+
+    <!-- TODO: Declare runtime permissions such as RECORD_AUDIO and POST_NOTIFICATIONS when wiring recording. -->
+
+    <application
+        android:name=".BiographyApplication"
+        android:allowBackup="true"
+        android:icon="@android:drawable/ic_btn_speak_now"
+        android:label="@string/app_name"
+        android:roundIcon="@android:drawable/ic_btn_speak_now"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name="com.yourcompany.biography.ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name="com.yourcompany.biography.service.RecordingForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection">
+            <!-- TODO: Verify foreground service type for media capture scenarios. -->
+        </service>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/yourcompany/biography/BiographyApplication.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/BiographyApplication.kt
@@ -1,0 +1,19 @@
+package com.yourcompany.biography
+
+import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import javax.inject.Inject
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class BiographyApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override fun getWorkManagerConfiguration(): Configuration =
+        Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyDao.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyDao.kt
@@ -1,0 +1,16 @@
+package com.yourcompany.biography.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BiographyDao {
+    @Query("SELECT * FROM biography_entries ORDER BY createdAt DESC")
+    fun observeEntries(): Flow<List<BiographyEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertEntry(entry: BiographyEntity)
+}

--- a/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyDatabase.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyDatabase.kt
@@ -1,0 +1,13 @@
+package com.yourcompany.biography.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [BiographyEntity::class],
+    version = 1,
+    exportSchema = true
+)
+abstract class BiographyDatabase : RoomDatabase() {
+    abstract fun biographyDao(): BiographyDao
+}

--- a/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyEntity.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/local/BiographyEntity.kt
@@ -1,0 +1,12 @@
+package com.yourcompany.biography.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "biography_entries")
+data class BiographyEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val prompt: String,
+    val answer: String,
+    val createdAt: Long
+)

--- a/android/app/src/main/java/com/yourcompany/biography/data/remote/BiographyApiService.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/remote/BiographyApiService.kt
@@ -1,0 +1,9 @@
+package com.yourcompany.biography.data.remote
+
+import com.yourcompany.biography.model.BiographyPromptDto
+import retrofit2.http.GET
+
+interface BiographyApiService {
+    @GET("prompts")
+    suspend fun fetchPrompts(): List<BiographyPromptDto>
+}

--- a/android/app/src/main/java/com/yourcompany/biography/data/repo/BiographyRepository.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/repo/BiographyRepository.kt
@@ -1,0 +1,14 @@
+package com.yourcompany.biography.data.repo
+
+import com.yourcompany.biography.model.BiographyEntry
+import com.yourcompany.biography.model.BiographyPrompt
+import com.yourcompany.biography.util.Result
+import kotlinx.coroutines.flow.Flow
+
+interface BiographyRepository {
+    val recordedEntries: Flow<List<BiographyEntry>>
+
+    suspend fun saveEntry(prompt: String, answer: String): Result<Unit>
+
+    suspend fun fetchPrompts(): Result<List<BiographyPrompt>>
+}

--- a/android/app/src/main/java/com/yourcompany/biography/data/repo/DefaultBiographyRepository.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/data/repo/DefaultBiographyRepository.kt
@@ -1,0 +1,77 @@
+package com.yourcompany.biography.data.repo
+
+import com.yourcompany.biography.data.local.BiographyDao
+import com.yourcompany.biography.data.local.BiographyEntity
+import com.yourcompany.biography.data.remote.BiographyApiService
+import com.yourcompany.biography.di.IoDispatcher
+import com.yourcompany.biography.model.BiographyEntry
+import com.yourcompany.biography.model.BiographyPrompt
+import com.yourcompany.biography.model.BiographyPromptDto
+import com.yourcompany.biography.util.AppLogger
+import com.yourcompany.biography.util.DateTimeUtils
+import com.yourcompany.biography.util.Result
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+@Singleton
+class DefaultBiographyRepository @Inject constructor(
+    private val biographyDao: BiographyDao,
+    private val apiService: BiographyApiService,
+    private val dateTimeUtils: DateTimeUtils,
+    private val logger: AppLogger,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher
+) : BiographyRepository {
+
+    override val recordedEntries: Flow<List<BiographyEntry>> =
+        biographyDao.observeEntries().map { entities ->
+            entities.map { entity ->
+                BiographyEntry(
+                    id = entity.id,
+                    prompt = entity.prompt,
+                    answer = entity.answer,
+                    createdAt = entity.createdAt
+                )
+            }
+        }
+
+    override suspend fun saveEntry(prompt: String, answer: String): Result<Unit> =
+        withContext(dispatcher) {
+            try {
+                val timestamp = System.currentTimeMillis()
+                logger.i(TAG, "Saving entry at ${dateTimeUtils.format(timestamp)}")
+                biographyDao.insertEntry(
+                    BiographyEntity(
+                        prompt = prompt,
+                        answer = answer,
+                        createdAt = timestamp
+                    )
+                )
+                Result.Success(Unit)
+            } catch (throwable: Throwable) {
+                logger.e(TAG, "Failed to save entry", throwable)
+                Result.Error(throwable)
+            }
+        }
+
+    override suspend fun fetchPrompts(): Result<List<BiographyPrompt>> =
+        withContext(dispatcher) {
+            try {
+                val prompts = apiService.fetchPrompts().map { it.toDomain() }
+                Result.Success(prompts)
+            } catch (throwable: Throwable) {
+                logger.e(TAG, "Failed to load prompts", throwable)
+                Result.Error(throwable)
+            }
+        }
+
+    private fun BiographyPromptDto.toDomain(): BiographyPrompt =
+        BiographyPrompt(id = id, question = question, category = category)
+
+    private companion object {
+        const val TAG = "BiographyRepository"
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/di/DatabaseModule.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/di/DatabaseModule.kt
@@ -1,0 +1,33 @@
+package com.yourcompany.biography.di
+
+import android.content.Context
+import androidx.room.Room
+import com.yourcompany.biography.data.local.BiographyDao
+import com.yourcompany.biography.data.local.BiographyDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(
+        @ApplicationContext context: Context
+    ): BiographyDatabase =
+        Room.databaseBuilder(
+            context,
+            BiographyDatabase::class.java,
+            "biography.db"
+        ).fallbackToDestructiveMigration()
+            .build()
+
+    @Provides
+    fun provideBiographyDao(database: BiographyDatabase): BiographyDao =
+        database.biographyDao()
+}

--- a/android/app/src/main/java/com/yourcompany/biography/di/DispatchersModule.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/di/DispatchersModule.kt
@@ -1,0 +1,22 @@
+package com.yourcompany.biography.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+
+    @IoDispatcher
+    @Provides
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/android/app/src/main/java/com/yourcompany/biography/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/di/NetworkModule.kt
@@ -1,0 +1,58 @@
+package com.yourcompany.biography.di
+
+import com.yourcompany.biography.data.remote.BiographyApiService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor =
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        json: Json,
+        okHttpClient: OkHttpClient
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl("https://example.com/")
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideBiographyApiService(retrofit: Retrofit): BiographyApiService =
+        retrofit.create(BiographyApiService::class.java)
+}

--- a/android/app/src/main/java/com/yourcompany/biography/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/di/RepositoryModule.kt
@@ -1,0 +1,20 @@
+package com.yourcompany.biography.di
+
+import com.yourcompany.biography.data.repo.BiographyRepository
+import com.yourcompany.biography.data.repo.DefaultBiographyRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBiographyRepository(
+        repository: DefaultBiographyRepository
+    ): BiographyRepository
+}

--- a/android/app/src/main/java/com/yourcompany/biography/model/BiographyEntry.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/model/BiographyEntry.kt
@@ -1,0 +1,8 @@
+package com.yourcompany.biography.model
+
+data class BiographyEntry(
+    val id: Long,
+    val prompt: String,
+    val answer: String,
+    val createdAt: Long
+)

--- a/android/app/src/main/java/com/yourcompany/biography/model/BiographyPrompt.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/model/BiographyPrompt.kt
@@ -1,0 +1,7 @@
+package com.yourcompany.biography.model
+
+data class BiographyPrompt(
+    val id: String,
+    val question: String,
+    val category: String? = null
+)

--- a/android/app/src/main/java/com/yourcompany/biography/model/BiographyPromptDto.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/model/BiographyPromptDto.kt
@@ -1,0 +1,11 @@
+package com.yourcompany.biography.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BiographyPromptDto(
+    @SerialName("id") val id: String,
+    @SerialName("question") val question: String,
+    @SerialName("category") val category: String? = null
+)

--- a/android/app/src/main/java/com/yourcompany/biography/service/RecordingForegroundService.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/service/RecordingForegroundService.kt
@@ -1,0 +1,70 @@
+package com.yourcompany.biography.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.yourcompany.biography.R
+import com.yourcompany.biography.util.AppLogger
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class RecordingForegroundService : Service() {
+
+    @Inject
+    lateinit var logger: AppLogger
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        logger.i(TAG, "Foreground service started")
+        startForeground(NOTIFICATION_ID, buildNotification())
+        // TODO: Connect to audio recording session and control lifecycle.
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        logger.i(TAG, "Foreground service destroyed")
+        super.onDestroy()
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.notification_recording))
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setOngoing(true)
+            .build()
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = getString(R.string.notification_channel_description)
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "recording_channel"
+        private const val NOTIFICATION_ID = 1
+        private const val TAG = "RecordingService"
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/MainActivity.kt
@@ -1,0 +1,34 @@
+package com.yourcompany.biography.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.yourcompany.biography.ui.theme.BiographyTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            BiographyApp()
+        }
+    }
+}
+
+@Composable
+fun BiographyApp() {
+    BiographyTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            MainScreen()
+        }
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/MainScreen.kt
@@ -1,0 +1,79 @@
+package com.yourcompany.biography.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yourcompany.biography.R
+import com.yourcompany.biography.ui.recorder.RecorderControls
+import com.yourcompany.biography.ui.theme.BiographyTheme
+import com.yourcompany.biography.ui.wizard.WizardScreen
+
+@Composable
+fun MainScreen(
+    modifier: Modifier = Modifier,
+    onStartRecording: () -> Unit = {},
+    onStopRecording: () -> Unit = {}
+) {
+    Scaffold(modifier = modifier.fillMaxSize()) { paddingValues ->
+        Content(
+            paddingValues = paddingValues,
+            onStartRecording = onStartRecording,
+            onStopRecording = onStopRecording
+        )
+    }
+}
+
+@Composable
+private fun Content(
+    paddingValues: PaddingValues,
+    onStartRecording: () -> Unit,
+    onStopRecording: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.app_name),
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        WizardScreen(
+            modifier = Modifier.fillMaxWidth(),
+            onPromptSelected = {
+                // TODO: Connect to navigation or prompt handling logic.
+            }
+        )
+        RecorderControls(
+            modifier = Modifier.fillMaxWidth(),
+            onStartRecording = onStartRecording,
+            onStopRecording = onStopRecording,
+            buttonText = stringResource(id = R.string.start_recording),
+            buttonContentDescription = stringResource(id = R.string.start_recording_talkback_label)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MainScreenPreview() {
+    BiographyTheme {
+        MainScreen()
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/ui/recorder/RecorderControls.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/recorder/RecorderControls.kt
@@ -1,0 +1,62 @@
+package com.yourcompany.biography.ui.recorder
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yourcompany.biography.ui.theme.BiographyTheme
+
+@Composable
+fun RecorderControls(
+    modifier: Modifier = Modifier,
+    onStartRecording: () -> Unit = {},
+    onStopRecording: () -> Unit = {},
+    buttonText: String,
+    buttonContentDescription: String? = null
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Button(
+            onClick = onStartRecording,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .padding(horizontal = 8.dp)
+                .let { base ->
+                    if (buttonContentDescription != null) {
+                        base.semantics { contentDescription = buttonContentDescription }
+                    } else {
+                        base
+                    }
+                },
+            colors = ButtonDefaults.buttonColors()
+        ) {
+            Text(
+                text = buttonText,
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
+        // Future stop/pause controls can be added here.
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RecorderControlsPreview() {
+    BiographyTheme {
+        RecorderControls(buttonText = "녹음 시작", buttonContentDescription = "녹음 시작 버튼")
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/theme/Color.kt
@@ -1,0 +1,7 @@
+package com.yourcompany.biography.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)

--- a/android/app/src/main/java/com/yourcompany/biography/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/theme/Theme.kt
@@ -1,0 +1,60 @@
+package com.yourcompany.biography.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+)
+
+@Composable
+fun BiographyTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as? Activity)?.window
+            window?.statusBarColor = colorScheme.primary.toArgb()
+            window?.let {
+                WindowCompat.getInsetsController(it, view).isAppearanceLightStatusBars = !darkTheme
+            }
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/android/app/src/main/java/com/yourcompany/biography/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.yourcompany.biography.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/android/app/src/main/java/com/yourcompany/biography/ui/wizard/WizardScreen.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/ui/wizard/WizardScreen.kt
@@ -1,0 +1,96 @@
+package com.yourcompany.biography.ui.wizard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yourcompany.biography.ui.theme.BiographyTheme
+
+@Composable
+fun WizardScreen(
+    modifier: Modifier = Modifier,
+    prompts: List<String> = samplePrompts,
+    onPromptSelected: (String) -> Unit
+) {
+    var selectedPrompt by remember(prompts) { mutableStateOf(prompts.firstOrNull().orEmpty()) }
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "오늘의 질문",
+                style = MaterialTheme.typography.titleLarge
+            )
+            prompts.take(MAX_VISIBLE_PROMPTS).forEach { prompt ->
+                WizardPromptItem(
+                    prompt = prompt,
+                    isSelected = prompt == selectedPrompt,
+                    onClick = {
+                        selectedPrompt = prompt
+                        onPromptSelected(prompt)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WizardPromptItem(
+    prompt: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val background = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = background),
+        onClick = onClick
+    ) {
+        Text(
+            text = prompt,
+            modifier = Modifier.padding(12.dp),
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+private const val MAX_VISIBLE_PROMPTS = 3
+
+private val samplePrompts = listOf(
+    "가장 기억에 남는 어린 시절 추억은 무엇인가요?",
+    "당신에게 가장 큰 영향을 준 사람은 누구인가요?",
+    "지금의 당신을 만든 결정적인 순간은 언제였나요?"
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun WizardScreenPreview() {
+    BiographyTheme {
+        WizardScreen(onPromptSelected = {})
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/util/AppLogger.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/util/AppLogger.kt
@@ -1,0 +1,16 @@
+package com.yourcompany.biography.util
+
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppLogger @Inject constructor() {
+    fun i(tag: String, message: String) {
+        Log.i(tag, message)
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        Log.e(tag, message, throwable)
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/util/DateTimeUtils.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/util/DateTimeUtils.kt
@@ -1,0 +1,18 @@
+package com.yourcompany.biography.util
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DateTimeUtils @Inject constructor() {
+    private val formatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault())
+
+    fun nowIso(): String = Instant.now().toString()
+
+    fun format(timestamp: Long): String =
+        formatter.format(Instant.ofEpochMilli(timestamp))
+}

--- a/android/app/src/main/java/com/yourcompany/biography/util/EncryptedFileManager.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/util/EncryptedFileManager.kt
@@ -1,0 +1,45 @@
+package com.yourcompany.biography.util
+
+import android.content.Context
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EncryptedFileManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val masterKey by lazy {
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+    }
+
+    fun writeText(fileName: String, content: String) {
+        val encryptedFile = createEncryptedFile(fileName)
+        encryptedFile.openFileOutput().use { outputStream ->
+            outputStream.write(content.encodeToByteArray())
+        }
+    }
+
+    fun readText(fileName: String): String? {
+        val encryptedFile = createEncryptedFile(fileName)
+        if (!encryptedFile.file.exists()) return null
+        return encryptedFile.openFileInput().use { inputStream ->
+            inputStream.readBytes().decodeToString()
+        }
+    }
+
+    private fun createEncryptedFile(fileName: String): EncryptedFile {
+        val file = File(context.filesDir, fileName)
+        return EncryptedFile.Builder(
+            context,
+            file,
+            masterKey,
+            EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+        ).build()
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/util/MimeTypeResolver.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/util/MimeTypeResolver.kt
@@ -1,0 +1,11 @@
+package com.yourcompany.biography.util
+
+import android.webkit.MimeTypeMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MimeTypeResolver @Inject constructor() {
+    fun fromExtension(extension: String): String? =
+        MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.lowercase())
+}

--- a/android/app/src/main/java/com/yourcompany/biography/util/Result.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/util/Result.kt
@@ -1,0 +1,14 @@
+package com.yourcompany.biography.util
+
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Error(val throwable: Throwable) : Result<Nothing>()
+
+    val isSuccess: Boolean get() = this is Success
+    val isError: Boolean get() = this is Error
+
+    inline fun <R> map(transform: (T) -> R): Result<R> = when (this) {
+        is Success -> Success(transform(data))
+        is Error -> this
+    }
+}

--- a/android/app/src/main/java/com/yourcompany/biography/worker/RecordingWorker.kt
+++ b/android/app/src/main/java/com/yourcompany/biography/worker/RecordingWorker.kt
@@ -1,0 +1,38 @@
+package com.yourcompany.biography.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.yourcompany.biography.data.repo.BiographyRepository
+import com.yourcompany.biography.util.AppLogger
+import com.yourcompany.biography.util.Result
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class RecordingWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParameters: WorkerParameters,
+    private val repository: BiographyRepository,
+    private val logger: AppLogger
+) : CoroutineWorker(appContext, workerParameters) {
+
+    override suspend fun doWork(): androidx.work.ListenableWorker.Result {
+        logger.i(TAG, "RecordingWorker started")
+        return when (val result = repository.fetchPrompts()) {
+            is Result.Success -> {
+                logger.i(TAG, "Fetched ${result.data.size} prompts for offline cache")
+                androidx.work.ListenableWorker.Result.success()
+            }
+            is Result.Error -> {
+                logger.e(TAG, "Failed to refresh prompts", result.throwable)
+                androidx.work.ListenableWorker.Result.retry()
+            }
+        }
+    }
+
+    companion object {
+        const val TAG = "RecordingWorker"
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<resources>
+    <string name="app_name">SOON Autobiography</string>
+    <string name="start_recording">녹음 시작</string>
+    <string name="start_recording_talkback_label">녹음 시작 버튼</string>
+    <string name="notification_recording">생애 기록을 위해 녹음 중입니다</string>
+    <string name="notification_channel_name">녹음 진행 알림</string>
+    <string name="notification_channel_description">진행 중인 오디오 녹음 상태를 제공합니다.</string>
+</resources>

--- a/android/app/src/test/java/com/yourcompany/biography/ExampleUnitTest.kt
+++ b/android/app/src/test/java/com/yourcompany/biography/ExampleUnitTest.kt
@@ -1,0 +1,11 @@
+package com.yourcompany.biography
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,1 +1,7 @@
-// Placeholder build.gradle.kts for the Android app module
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,56 @@
+[versions]
+agp = "8.2.2"
+kotlin = "1.9.22"
+compose-bom = "2024.05.00"
+compose-compiler = "1.5.11"
+androidx-activity = "1.9.0"
+androidx-core = "1.13.1"
+lifecycle = "2.7.0"
+hilt = "2.51.1"
+room = "2.6.1"
+work = "2.9.0"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+serialization = "1.6.3"
+coroutines = "1.8.1"
+security-crypto = "1.1.0-alpha06"
+hilt-androidx = "1.1.0"
+junit = "4.13.2"
+androidx-test-ext = "1.1.5"
+espresso = "3.5.1"
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-androidx" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hilt-androidx" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-work-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,1 +1,18 @@
-// Placeholder settings.gradle.kts for the Android project
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Biography"
+include(":app")


### PR DESCRIPTION
## Summary
- scaffold an Android application module using Jetpack Compose, Hilt, Room, WorkManager, Retrofit, and Kotlinx Serialization for `com.yourcompany.biography`
- implement accessibility-friendly main UI with recording controls, wizard placeholders, encrypted storage utilities, and DI modules
- document build steps, permissions, and TODOs in `README_app.md`

## Testing
- ./gradlew --console=plain help

------
https://chatgpt.com/codex/tasks/task_e_68d3738f4b048329a0bdfdf28f45217f